### PR TITLE
build: add cicd in .github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: ci
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set node version to 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Install Dependencies
+        run: npm ci
+
+  build:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set node version to 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Test Build
+        run: npm run build


### PR DESCRIPTION
<!--
Thank you for contributing!
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

## Context

<!--
Please link to a Github issue (type `#` to autocomplete issue)
Example: `Closes #1` will close issue number 1.
-->

This is a configuration file for a GitHub Actions workflow named `ci`, which specifies a set of tasks to be executed automatically when a pull request is made to the main branch of a repository.


<!-- OR provide a brief explanation about the problem -->

## Implementation

<!-- Briefly explain how your solution solves the problem -->
<!-- If it affects UI, an image or gif is greatly encouraged. -->
The workflow includes two jobs: `install` and `build`. The install job runs first and sets up the environment by checking out the repository, setting the Node.js version to 16, and installing the necessary dependencies using the `npm ci` command.

The build job runs after the install job completes and includes the same setup steps. Additionally, it installs dependencies and runs the npm run build command, which tests the build process of the application.

The `needs: install` option in the build job indicates that it depends on the successful completion of the install job. If the install job fails, the build job will not be executed.

## Other Information

<!--
This section is optional and will be for:
- Any additional questions
- Any assistance you need
- Any tasks that are incomplete
- Any important information (for example, how do we test your code?)
- Letting us know that you're new to this (so we know how much to help out)
-->

Overall, this GitHub Actions workflow ensures that the dependencies are correctly installed, and the application builds successfully, thereby providing an automated testing and validation process for changes made to the codebase.